### PR TITLE
Improve mod stats include_metric matcher

### DIFF
--- a/spec/modularization_statistics_spec.rb
+++ b/spec/modularization_statistics_spec.rb
@@ -42,36 +42,6 @@ module ModularizationStatistics # rubocop:disable RSpec/DescribedClassModuleWrap
     end
 
     describe 'ModularizationStatistics.get_metrics' do
-      RSpec::Matchers.define(:include_metric) do |expected_metric|
-        match do |actual_metrics|
-          @actual_metrics = actual_metrics
-          @expected_metric = expected_metric
-          @matching_metrics = actual_metrics.select { |actual_metric| actual_metric.name == expected_metric.name }
-          @actual_metric = @matching_metrics.find { |matching_metric| matching_metric.count == expected_metric.count && expected_metric.tags.sort_by(&:key) == matching_metric.tags.sort_by(&:key) }
-          @matching_metrics.any? && !@actual_metric.nil?
-        end
-
-        description do
-          "to have a metric named `#{expected_metric.name}` with count of #{expected_metric.count} and tags of #{expected_metric.tags.map(&:to_s)}"
-        end
-
-        failure_message do
-          if @matching_metrics.none?
-            "Could not find metric with name `#{expected_metric.name}` Could only find metrics with names: #{@actual_metrics.map(&:name)}"
-          else
-            count_diff = "Actual count: #{@matching_metrics.map(&:count)}\nExpected count: #{expected_metric.count}"
-            actual_tags = @matching_metrics.map { |matching_metric| matching_metric.tags.map(&:to_s) }
-            expected_tags = expected_metric.tags.map(&:to_s)
-            tags_diff = "Actual tags (not in expected): #{actual_tags.map { |actual| actual - expected_tags }}\nExpected tags (not in actual): #{expected_tags - actual_tags}"
-            <<~FAILURE_MESSAGE
-              Expected and actual metric `#{expected_metric.name}` are not equal. Found #{@matching_metrics.count} metrics with matching name `#{@expected_metric.name}`, but the properties are different
-              #{count_diff}
-              #{tags_diff}
-            FAILURE_MESSAGE
-          end
-        end
-      end
-
       let(:subject) do
         ModularizationStatistics.get_metrics(
           app_name: 'MyApp',

--- a/spec/modularization_statistics_spec.rb
+++ b/spec/modularization_statistics_spec.rb
@@ -428,7 +428,7 @@ module ModularizationStatistics # rubocop:disable RSpec/DescribedClassModuleWrap
           expect(metrics).to include_metric GaugeMetric.for('by_team.all_packages.count', 1, Tags.for(['team:Chefs', 'app:MyApp']))
           expect(metrics).to include_metric GaugeMetric.for('by_team.dependency_violations.count', 5, Tags.for(['team:Chefs', 'app:MyApp']))
           expect(metrics).to include_metric GaugeMetric.for('by_team.privacy_violations.count', 0, Tags.for(['team:Chefs', 'app:MyApp']))
-          expect(metrics).to include_metric GaugeMetric.for('by_team.outbound_dependency_violations.count', 3, Tags.for(['team:Chefs', 'app:MyApp']))
+          expect(metrics).to include_metric GaugeMetric.for('by_team.outbound_dependency_violations.count', 2, Tags.for(['team:Chefs', 'app:MyApp']))
           expect(metrics).to include_metric GaugeMetric.for('by_team.inbound_dependency_violations.count', 2, Tags.for(['team:Chefs', 'app:MyApp']))
           expect(metrics).to include_metric GaugeMetric.for('by_team.outbound_privacy_violations.count', 0, Tags.for(['team:Chefs', 'app:MyApp']))
           expect(metrics).to include_metric GaugeMetric.for('by_team.inbound_privacy_violations.count', 0, Tags.for(['team:Chefs', 'app:MyApp']))

--- a/spec/modularization_statistics_spec.rb
+++ b/spec/modularization_statistics_spec.rb
@@ -428,7 +428,7 @@ module ModularizationStatistics # rubocop:disable RSpec/DescribedClassModuleWrap
           expect(metrics).to include_metric GaugeMetric.for('by_team.all_packages.count', 1, Tags.for(['team:Chefs', 'app:MyApp']))
           expect(metrics).to include_metric GaugeMetric.for('by_team.dependency_violations.count', 5, Tags.for(['team:Chefs', 'app:MyApp']))
           expect(metrics).to include_metric GaugeMetric.for('by_team.privacy_violations.count', 0, Tags.for(['team:Chefs', 'app:MyApp']))
-          expect(metrics).to include_metric GaugeMetric.for('by_team.outbound_dependency_violations.count', 2, Tags.for(['team:Chefs', 'app:MyApp']))
+          expect(metrics).to include_metric GaugeMetric.for('by_team.outbound_dependency_violations.count', 3, Tags.for(['team:Chefs', 'app:MyApp']))
           expect(metrics).to include_metric GaugeMetric.for('by_team.inbound_dependency_violations.count', 2, Tags.for(['team:Chefs', 'app:MyApp']))
           expect(metrics).to include_metric GaugeMetric.for('by_team.outbound_privacy_violations.count', 0, Tags.for(['team:Chefs', 'app:MyApp']))
           expect(metrics).to include_metric GaugeMetric.for('by_team.inbound_privacy_violations.count', 0, Tags.for(['team:Chefs', 'app:MyApp']))

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -55,3 +55,33 @@ RSpec.shared_context 'only one team' do
     allow(CodeOwnership).to receive(:for_file).and_return(sorbet_double(CodeTeams::Team, name: 'Some team'))
   end
 end
+
+RSpec::Matchers.define(:include_metric) do |expected_metric|
+  match do |actual_metrics|
+    @actual_metrics = actual_metrics
+    @expected_metric = expected_metric
+    @matching_metrics = actual_metrics.select { |actual_metric| actual_metric.name == expected_metric.name }
+    @actual_metric = @matching_metrics.find { |matching_metric| matching_metric.count == expected_metric.count && expected_metric.tags.sort_by(&:key) == matching_metric.tags.sort_by(&:key) }
+    @matching_metrics.any? && !@actual_metric.nil?
+  end
+
+  description do
+    "to have a metric named `#{expected_metric.name}` with count of #{expected_metric.count} and tags of #{expected_metric.tags.map(&:to_s)}"
+  end
+
+  failure_message do
+    if @matching_metrics.none?
+      "Could not find metric with name `#{expected_metric.name}` Could only find metrics with names: \n\n#{@actual_metrics.sort_by(&:name).uniq.join("\n")}"
+    else
+      count_diff = "Actual count: #{@matching_metrics.map(&:count)}\nExpected count: #{expected_metric.count}"
+      actual_tags = @matching_metrics.map { |matching_metric| matching_metric.tags.map(&:to_s) }
+      expected_tags = expected_metric.tags.map(&:to_s)
+      tags_diff = "Actual tags (not in expected): #{actual_tags.map { |actual| actual - expected_tags }}\nExpected tags (not in actual): #{expected_tags - actual_tags}"
+      <<~FAILURE_MESSAGE
+        Expected and actual metric `#{expected_metric.name}` are not equal. Found #{@matching_metrics.count} metrics with matching name `#{@expected_metric.name}`, but the properties are different
+        #{count_diff}
+        #{tags_diff}
+      FAILURE_MESSAGE
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -73,7 +73,25 @@ RSpec::Matchers.define(:include_metric) do |expected_metric|
     if @metrics_with_same_name.none?
       "Could not find metric:\n\n#{expected_metric}\n\nCould only find metrics with names: \n\n#{@actual_metrics.sort_by(&:name).uniq.join("\n")}"
     else
-      "Could not find metric:\n\n#{expected_metric}\n\nCould only find metrics with counts: \n\n#{@metrics_with_same_name.sort_by(&:name).uniq.join("\n")}"
+
+      # We colorize each part of the output red (if there is no match) or green (if there is a partial match)
+      colorized_metrics = @metrics_with_same_name.sort_by(&:name).map do |actual_metric|
+        count_equal = actual_metric.count == expected_metric.count
+        with_count = "with count #{actual_metric.count}"
+        colorized_with_count = count_equal ? Rainbow(with_count).green : Rainbow(with_count).red
+
+        tags = actual_metric.tags.sort_by(&:key).map do |tag|
+          if expected_metric.tags.include?(tag)
+            Rainbow(tag.to_s).green
+          else
+            Rainbow(tag.to_s).red
+          end
+        end
+
+        "#{Rainbow(actual_metric.name).green} #{colorized_with_count}, with tags #{tags.join(', ')}"
+      end
+
+      "Could not find metric:\n\n#{expected_metric}\n\nCould only find metrics: \n\n#{colorized_metrics.join("\n")}"
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -60,9 +60,9 @@ RSpec::Matchers.define(:include_metric) do |expected_metric|
   match do |actual_metrics|
     @actual_metrics = actual_metrics
     @expected_metric = expected_metric
-    @matching_metrics = actual_metrics.select { |actual_metric| actual_metric.name == expected_metric.name }
-    @actual_metric = @matching_metrics.find { |matching_metric| matching_metric.count == expected_metric.count && expected_metric.tags.sort_by(&:key) == matching_metric.tags.sort_by(&:key) }
-    @matching_metrics.any? && !@actual_metric.nil?
+    @metrics_with_same_name = actual_metrics.select { |actual_metric| actual_metric.name == expected_metric.name }
+    @matching_metric = @metrics_with_same_name.find { |matching_metric| matching_metric.count == expected_metric.count && expected_metric.tags.sort_by(&:key) == matching_metric.tags.sort_by(&:key) }
+    @metrics_with_same_name.any? && !@matching_metric.nil?
   end
 
   description do
@@ -70,18 +70,10 @@ RSpec::Matchers.define(:include_metric) do |expected_metric|
   end
 
   failure_message do
-    if @matching_metrics.none?
-      "Could not find metric with name `#{expected_metric.name}` Could only find metrics with names: \n\n#{@actual_metrics.sort_by(&:name).uniq.join("\n")}"
+    if @metrics_with_same_name.none?
+      "Could not find metric:\n\n#{expected_metric}\n\nCould only find metrics with names: \n\n#{@actual_metrics.sort_by(&:name).uniq.join("\n")}"
     else
-      count_diff = "Actual count: #{@matching_metrics.map(&:count)}\nExpected count: #{expected_metric.count}"
-      actual_tags = @matching_metrics.map { |matching_metric| matching_metric.tags.map(&:to_s) }
-      expected_tags = expected_metric.tags.map(&:to_s)
-      tags_diff = "Actual tags (not in expected): #{actual_tags.map { |actual| actual - expected_tags }}\nExpected tags (not in actual): #{expected_tags - actual_tags}"
-      <<~FAILURE_MESSAGE
-        Expected and actual metric `#{expected_metric.name}` are not equal. Found #{@matching_metrics.count} metrics with matching name `#{@expected_metric.name}`, but the properties are different
-        #{count_diff}
-        #{tags_diff}
-      FAILURE_MESSAGE
+      "Could not find metric:\n\n#{expected_metric}\n\nCould only find metrics with counts: \n\n#{@metrics_with_same_name.sort_by(&:name).uniq.join("\n")}"
     end
   end
 end


### PR DESCRIPTION
The old matcher made it really hard to understand what was wrong. Here are screenshots:

# Before when there was no metric with the same name
<img width="1452" alt="Screen Shot 2022-08-18 at 7 51 55 AM" src="https://user-images.githubusercontent.com/3311200/185393005-c6ea5ba0-b618-4bc5-9c29-6d55f30807b7.png">

# Before when there was a matching metric with different counts or tags
<img width="1489" alt="Screen Shot 2022-08-18 at 8 07 24 AM" src="https://user-images.githubusercontent.com/3311200/185393043-bddccbf3-8199-4661-9cce-221465e01857.png">

# After when there was no metric with the same name
<img width="1385" alt="Screen Shot 2022-08-18 at 7 56 36 AM" src="https://user-images.githubusercontent.com/3311200/185393089-40317639-9e4b-46ad-a734-d076e9dad3b4.png">

# After when there was a matching metric with different counts or tags
<img width="1475" alt="Screen Shot 2022-08-18 at 8 17 57 AM" src="https://user-images.githubusercontent.com/3311200/185393114-9fc84463-e1a4-41cd-8724-0dfe56b938e2.png">
