### PR TITLE
Add missing metrics for per pack group

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    modularization_statistics (1.35.0)
+    modularization_statistics (1.36.0)
       code_ownership
       code_teams
       dogapi

--- a/modularization_statistics.gemspec
+++ b/modularization_statistics.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'modularization_statistics'
-  spec.version       = '1.35.0'
+  spec.version       = '1.36.0'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
 

--- a/spec/modularization_statistics_spec.rb
+++ b/spec/modularization_statistics_spec.rb
@@ -1113,16 +1113,16 @@ module ModularizationStatistics # rubocop:disable RSpec/DescribedClassModuleWrap
           expect(metrics).to include_metric GaugeMetric.for('all_pack_groups.dependency_violations.count', 3, Tags.for(['app:MyApp']))
 
           expect(metrics).to include_metric GaugeMetric.for('by_pack_group.outbound_dependency_violations.count', 2, Tags.for(['app:MyApp', 'pack_group:root']))
-          expect(metrics).to include_metric GaugeMetric.for('by_pack_group.outbound_dependency_violations.count', 1, Tags.for(['app:MyApp', 'pack_group:fruits']))
-          expect(metrics).to include_metric GaugeMetric.for('by_pack_group.outbound_dependency_violations.count', 0, Tags.for(['app:MyApp', 'pack_group:vegetables']))
-          expect(metrics).to include_metric GaugeMetric.for('by_pack_group.outbound_dependency_violations.count', 0, Tags.for(['app:MyApp', 'pack_group:peanuts']))
-          expect(metrics).to include_metric GaugeMetric.for('by_pack_group.outbound_dependency_violations.count', 0, Tags.for(['app:MyApp', 'pack_group:cashews']))
+          expect(metrics).to include_metric GaugeMetric.for('by_pack_group.outbound_dependency_violations.count', 1, Tags.for(['app:MyApp', 'pack_group:packs/fruits']))
+          expect(metrics).to include_metric GaugeMetric.for('by_pack_group.outbound_dependency_violations.count', 0, Tags.for(['app:MyApp', 'pack_group:packs/vegetables']))
+          expect(metrics).to include_metric GaugeMetric.for('by_pack_group.outbound_dependency_violations.count', 0, Tags.for(['app:MyApp', 'pack_group:packs/peanuts']))
+          expect(metrics).to include_metric GaugeMetric.for('by_pack_group.outbound_dependency_violations.count', 0, Tags.for(['app:MyApp', 'pack_group:packs/cashews']))
 
           expect(metrics).to include_metric GaugeMetric.for('by_pack_group.inbound_privacy_violations.count', 0, Tags.for(['app:MyApp', 'pack_group:root']))
-          expect(metrics).to include_metric GaugeMetric.for('by_pack_group.inbound_privacy_violations.count', 2, Tags.for(['app:MyApp', 'pack_group:fruits']))
-          expect(metrics).to include_metric GaugeMetric.for('by_pack_group.inbound_privacy_violations.count', 0, Tags.for(['app:MyApp', 'pack_group:vegetables']))
-          expect(metrics).to include_metric GaugeMetric.for('by_pack_group.inbound_privacy_violations.count', 1, Tags.for(['app:MyApp', 'pack_group:peanuts']))
-          expect(metrics).to include_metric GaugeMetric.for('by_pack_group.inbound_privacy_violations.count', 0, Tags.for(['app:MyApp', 'pack_group:cashews']))
+          expect(metrics).to include_metric GaugeMetric.for('by_pack_group.inbound_privacy_violations.count', 2, Tags.for(['app:MyApp', 'pack_group:packs/fruits']))
+          expect(metrics).to include_metric GaugeMetric.for('by_pack_group.inbound_privacy_violations.count', 0, Tags.for(['app:MyApp', 'pack_group:packs/vegetables']))
+          expect(metrics).to include_metric GaugeMetric.for('by_pack_group.inbound_privacy_violations.count', 1, Tags.for(['app:MyApp', 'pack_group:packs/peanuts']))
+          expect(metrics).to include_metric GaugeMetric.for('by_pack_group.inbound_privacy_violations.count', 0, Tags.for(['app:MyApp', 'pack_group:packs/cashews']))
 
           # This does have a tag for pack group, but the metric itself also only sends information about cross-pack group violations.
           expect(metrics).to include_metric GaugeMetric.for('by_pack_group.outbound_dependency_violations.per_pack_group.count', 2, Tags.for(['app:MyApp', 'pack_group:root', 'to_pack_group:packs/fruits']))

--- a/spec/modularization_statistics_spec.rb
+++ b/spec/modularization_statistics_spec.rb
@@ -1112,6 +1112,18 @@ module ModularizationStatistics # rubocop:disable RSpec/DescribedClassModuleWrap
           expect(metrics).to include_metric GaugeMetric.for('all_pack_groups.privacy_violations.count', 3, Tags.for(['app:MyApp']))
           expect(metrics).to include_metric GaugeMetric.for('all_pack_groups.dependency_violations.count', 3, Tags.for(['app:MyApp']))
 
+          expect(metrics).to include_metric GaugeMetric.for('by_pack_group.outbound_dependency_violations.count', 2, Tags.for(['app:MyApp', 'pack_group:root']))
+          expect(metrics).to include_metric GaugeMetric.for('by_pack_group.outbound_dependency_violations.count', 1, Tags.for(['app:MyApp', 'pack_group:fruits']))
+          expect(metrics).to include_metric GaugeMetric.for('by_pack_group.outbound_dependency_violations.count', 0, Tags.for(['app:MyApp', 'pack_group:vegetables']))
+          expect(metrics).to include_metric GaugeMetric.for('by_pack_group.outbound_dependency_violations.count', 0, Tags.for(['app:MyApp', 'pack_group:peanuts']))
+          expect(metrics).to include_metric GaugeMetric.for('by_pack_group.outbound_dependency_violations.count', 0, Tags.for(['app:MyApp', 'pack_group:cashews']))
+
+          expect(metrics).to include_metric GaugeMetric.for('by_pack_group.inbound_privacy_violations.count', 0, Tags.for(['app:MyApp', 'pack_group:root']))
+          expect(metrics).to include_metric GaugeMetric.for('by_pack_group.inbound_privacy_violations.count', 2, Tags.for(['app:MyApp', 'pack_group:fruits']))
+          expect(metrics).to include_metric GaugeMetric.for('by_pack_group.inbound_privacy_violations.count', 0, Tags.for(['app:MyApp', 'pack_group:vegetables']))
+          expect(metrics).to include_metric GaugeMetric.for('by_pack_group.inbound_privacy_violations.count', 1, Tags.for(['app:MyApp', 'pack_group:peanuts']))
+          expect(metrics).to include_metric GaugeMetric.for('by_pack_group.inbound_privacy_violations.count', 0, Tags.for(['app:MyApp', 'pack_group:cashews']))
+
           # This does have a tag for pack group, but the metric itself also only sends information about cross-pack group violations.
           expect(metrics).to include_metric GaugeMetric.for('by_pack_group.outbound_dependency_violations.per_pack_group.count', 2, Tags.for(['app:MyApp', 'pack_group:root', 'to_pack_group:packs/fruits']))
           expect(metrics).to include_metric GaugeMetric.for('by_pack_group.outbound_privacy_violations.per_pack_group.count', 2, Tags.for(['app:MyApp', 'pack_group:root', 'to_pack_group:packs/fruits']))


### PR DESCRIPTION
Not sure how I missed this. I had metrics for the entire app (that is, across pack groups) and pack group to pack group, but for single pack groups.
